### PR TITLE
feat: email_input 뷰 구현

### DIFF
--- a/src/main/java/com/shop/coffee/order/controller/ApiV1AdminController.java
+++ b/src/main/java/com/shop/coffee/order/controller/ApiV1AdminController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Controller
@@ -27,8 +28,8 @@ public class ApiV1AdminController {
     }
 
     @GetMapping("/order-detail")
-    public String showAdminOrderDetail(@RequestParam("email") String email, Model model) {
-        AdminOrderDetailDto order = orderService.getOrderByEmail(email);
+    public String showAdminOrderDetail(@RequestParam("email") String email, LocalDateTime modifiedAt, Model model) {
+        AdminOrderDetailDto order = orderService.getOrderByEmailAndModifiedAt(email, modifiedAt);
         model.addAttribute("order", order);
         return "admin_order_detail";
 

--- a/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
+++ b/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
@@ -3,6 +3,7 @@ import com.shop.coffee.order.OrderStatus;
 import com.shop.coffee.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,5 +24,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByEmailAndOrderStatus(String email, OrderStatus orderStatus);
     Optional<Order> findByEmailAndOrderStatusAndAddressAndZipcode(String email, OrderStatus orderStatus, String address, String zipCode);
 
-    Optional<Object> findByEmail(String email);
+    Optional<Order> findByEmailAndModifiedAt(String email, LocalDateTime modifiedAt);
 }

--- a/src/main/java/com/shop/coffee/order/service/OrderService.java
+++ b/src/main/java/com/shop/coffee/order/service/OrderService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -47,10 +48,9 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public AdminOrderDetailDto getOrderByEmail(String email) {
-        Order order = (Order) orderRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException(NOSINGLEORDER.getMessage()));
-        return new AdminOrderDetailDto(order);
+    public AdminOrderDetailDto getOrderByEmailAndModifiedAt(String email, LocalDateTime modifiedAt) {
+        Optional<Order> order = orderRepository.findByEmailAndModifiedAt(email, modifiedAt);
+        return order.map(AdminOrderDetailDto::new).orElseThrow(() -> new EntityNotFoundException(NOSINGLEORDER.getMessage()));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/admin_order_list.html
+++ b/src/main/resources/templates/admin_order_list.html
@@ -24,7 +24,7 @@
         <td th:text="${order.totalPrice}"></td>
         <td th:text="${order.summaryItemName}"></td>
         <td>
-            <a th:href="@{/admin/order-detail(email=${order.email})}">주문상세</a> <!-- Order detail button added -->
+            <a th:href="@{/admin/order-detail(email=${order.email},modifiedAt=${order.modifiedAt})}">주문상세</a>
         </td>
     </tbody>
 </table>

--- a/src/main/resources/templates/email_input.html
+++ b/src/main/resources/templates/email_input.html
@@ -3,12 +3,96 @@
 <head>
     <meta charset="UTF-8">
     <title>Email Input</title>
+    <link rel="stylesheet" th:href="@{/css/output.css}">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@1.14.0/dist/full.css" rel="stylesheet">
+    <style>
+        .bg-white {
+            padding: 2rem;
+            width: 30rem;
+        }
+        .light-text {
+            color: #A0A0A0;
+            margin-top: 1rem;
+            display: flex;
+            white-space: nowrap;
+            align-items: center;
+        }
+        .btn-black {
+            background-color: #2C2C2C;
+            border-color: #2C2C2C;
+        }
+        .input-with-icon {
+            position: relative;
+        }
+        .input-with-icon input {
+            padding-right: 2.5rem;
+        }
+        .input-with-icon svg {
+            position: absolute;
+            right: 0.75rem;
+            top: 40%;
+            transform: translateY(-50%);
+            pointer-events: none;
+        }
+        .text-center {
+            border: 2px solid black;
+            padding: 2rem;
+            width: 60%;
+            margin: 0 auto;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            box-sizing: border-box;
+        }
+        .home-button {
+            position: absolute;
+            top: 2rem;
+            left: 2rem;
+            cursor: pointer;
+            background: none;
+            border: none;
+        }
+        .home-button svg {
+            width: 2rem;
+            height: 2rem;
+            position: absolute;
+            left: 12.5%;
+            right: 12.5%;
+            top: 8.33%;
+            bottom: 8.33%;
+            border: 4px solid #1E1E1E;
+        }
+    </style>
 </head>
-<body>
-<form action="/orders/check-email" method="post">
-    <label for="email">주문 내역 확인</label>
-    <input type="email" id="email" name="email" required>
-    <button type="submit">주문 내역 확인하기</button>
-</form>
+<body class="bg-gray-100 flex items-center justify-center h-screen">
+<button class="home-button" onclick="location.href='/orders/item-list'">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+    </svg>
+</button>
+<h1 class="text-4xl font-bold absolute top-12">Grids & Circle</h1>
+<div class="text-center">
+    <div class="bg-white p-8 rounded shadow-md w-96">
+        <form action="/orders/check-email" method="post">
+        <label for="email" class="block text-2xl font-bold mb-2">주문 내역 확인</label>
+        <p class="text-sm light-text mb-4">주문 내역을 확인하시려면 이메일을 입력해주세요</p>
+        <div class="input-with-icon">
+            <input type="email" id="email" name="email" class="input input-bordered w-full mb-4" placeholder="example@email.com" required>
+            <svg class="h-5 w-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M2 3a2 2 0 012-2h12a2 2 0 012 2v14a2 2 0 01-2 2H4a2 2 0 01-2-2V3zm2 0v14h12V3H4zm1.5 2.5l5 3.5 5-3.5V5l-5 3.5L5.5 5v.5z" />
+            </svg>
+        </div>
+        <button type="submit" class="btn btn-black w-full">주문 내역 확인하기</button>
+        <div class="light-text">
+            ✅ 주문 시 입력하신 이메일 주소를 입력해주세요
+        </div>
+        <div class="light-text">
+            ✅ 이메일 주소는 정확하게 입력해주세요
+        </div>
+        </form>
+    </div>
+</div>
 </body>
 </html>

--- a/src/test/java/com/shop/coffee/order/service/OrderServiceTest2.java
+++ b/src/test/java/com/shop/coffee/order/service/OrderServiceTest2.java
@@ -2,6 +2,7 @@ package com.shop.coffee.order.service;
 
 import com.shop.coffee.item.entity.Item;
 import com.shop.coffee.order.OrderStatus;
+import com.shop.coffee.order.dto.AdminOrderDetailDto;
 import com.shop.coffee.order.entity.Order;
 import com.shop.coffee.order.repository.OrderRepository;
 import com.shop.coffee.orderitem.entity.OrderItem;
@@ -13,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -122,16 +124,18 @@ class OrderServiceTest2 {
     }
 
     @Test
-    @DisplayName("이메일로 주문 조회 - 존재 여부 확인")
+    @DisplayName("이메일과 수정된 날짜로 주문 조회 - 존재 여부 확인")
     void test5() {
         // given
         String email = "user1@example.com";
-        when(orderRepository.findByEmail(email)).thenReturn(Optional.of(order1));
+        LocalDateTime modifiedAt = LocalDateTime.now();
+        Order order = new Order();
+        when(orderRepository.findByEmailAndModifiedAt(email, modifiedAt)).thenReturn(Optional.of(order));
 
         // when
-        Optional<Object> orderOptional = orderRepository.findByEmail(email);
+        AdminOrderDetailDto orderDetail = orderService.getOrderByEmailAndModifiedAt(email, modifiedAt);
 
         // then
-        assertTrue(orderOptional.isPresent());
+        assertNotNull(orderDetail);
     }
 }


### PR DESCRIPTION
### 💻 작업 내용
<!-- 해당 PR에서 작업한 내용, 변경 사항 등을 설명해주세요. -->
1. figma에서 디자인한 것과 최대한 유사하게 해봤는데 완전히 동일하게 하진 못했습니다. CSS 어렵네요..
2. 홈 버튼 클릭시 item_list로, 확인하기 버튼 누를 시 이메일이 있다면 해당 이메일의 order_list로, 없다면 다시 item_list로 돌아가는 것은 직접 확인했습니다.
3. 확인하기 버튼 누를 시 이메일이 없다면 사용자에게 없다는 메세지를 보여주고 item_list로 가게끔 해보려고 했는데 잘 안돼서 일단 바로 item_list로 리다이렉트 되는 것으로 했습니다.
4. html에서 input type을 email로 해두면 @가 없는 입력은 알아서 쳐내주는 것도 확인했습니다.
5. admin page에서 주문상세 기능을 구현할 때, 이메일만으로 주문을 찾으면 여러 객체가 나올 수 있기 때문에 수정

<br>

### ✅ 체크 리스트
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 풀 리퀘스트 제목에 커밋 메시지 컨벤션을 적용했습니다.

<br>

### ⚠️ 주의 사항
<!-- 주의해야 할 점, 참고해야 할 점이 있다면 설명해주세요. -->
<!-- 내용이 없다면 X를 입력하세요. -->
X

<br>

### 🗨️ 리뷰 요구 사항
<!-- 리뷰어가 중점적으로 확인해주길 바라는 부분을 작성하고, 리뷰어를 할당해주세요. -->
<!-- 리뷰가 필요하지 않다면 X를 입력하세요. -->
