### PR TITLE
refactor: 주문 통합 데이터 dto 전송

### DIFF
--- a/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
+++ b/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
 
     EXAMPLE("예시 메시지입니다."),
     NOSINGLEORDER("해당 주문이 존재하지 않습니다."),
-    NO_SINGLE_ITEM("해당 상품이 존재하지 않습니다.");
+    ITEM_NOT_FOUND("해당 상품이 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
+++ b/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     EXAMPLE("예시 메시지입니다."),
-    NOSINGLEORDER("해당 주문이 존재하지 않습니다.");
-
+    NOSINGLEORDER("해당 주문이 존재하지 않습니다."),
+    NOSINGLEITEM("해당 상품이 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
+++ b/src/main/java/com/shop/coffee/global/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
 
     EXAMPLE("예시 메시지입니다."),
     NOSINGLEORDER("해당 주문이 존재하지 않습니다."),
-    NOSINGLEITEM("해당 상품이 존재하지 않습니다.");
+    NO_SINGLE_ITEM("해당 상품이 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/com/shop/coffee/item/dto/ItemIntegrationDto.java
+++ b/src/main/java/com/shop/coffee/item/dto/ItemIntegrationDto.java
@@ -1,0 +1,21 @@
+package com.shop.coffee.item.dto;
+
+import com.shop.coffee.item.entity.Item;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemIntegrationDto {
+    private Long id;
+    private String name;
+    private String category;
+    private int price;
+
+    public ItemIntegrationDto(Item item) {
+        this.id = item.getId();
+        this.name = item.getName();
+        this.category = item.getCategory();
+        this.price = item.getPrice();
+    }
+}

--- a/src/main/java/com/shop/coffee/item/dto/ItemToOrderItemDto.java
+++ b/src/main/java/com/shop/coffee/item/dto/ItemToOrderItemDto.java
@@ -1,0 +1,32 @@
+package com.shop.coffee.item.dto;
+
+import com.shop.coffee.item.entity.Item;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemToOrderItemDto {
+    private Long id;
+    private String name;
+    private int price;
+    private int quantity;
+    private String imagePath;
+
+    public ItemToOrderItemDto() {}
+
+    public ItemToOrderItemDto(Item item) {
+        this.id = item.getId();
+        this.name = item.getName();
+        this.price = item.getPrice();
+        this.imagePath = item.getImagePath();
+    }
+
+    public ItemToOrderItemDto(Item item, int quantity) {
+        this.id = item.getId();
+        this.name = item.getName();
+        this.price = item.getPrice();
+        this.imagePath = item.getImagePath();
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/shop/coffee/order/controller/ApiV1OrderController.java
+++ b/src/main/java/com/shop/coffee/order/controller/ApiV1OrderController.java
@@ -35,7 +35,7 @@ public class ApiV1OrderController {
     public String processPayment(Model model, @RequestBody @Valid OrderPaymentRequestDto request
             , RedirectAttributes redirectAttributes) {
         OrderIntegrationViewDto result = orderService.processPayment(
-                request.getEmail(), request.getAddress(), request.getZipCode(), request.getOrderItems()
+                request.getEmail(), request.getAddress(), request.getZipCode(), request.getItems()
         );
 
         if (result.getViewName().equals("redirect:/orders/order-list")) {

--- a/src/main/java/com/shop/coffee/order/dto/OrderIntegrationDto.java
+++ b/src/main/java/com/shop/coffee/order/dto/OrderIntegrationDto.java
@@ -1,0 +1,32 @@
+package com.shop.coffee.order.dto;
+
+import com.shop.coffee.order.entity.Order;
+import com.shop.coffee.orderitem.dto.OrderItemIntegrationDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+public class OrderIntegrationDto {
+
+    private Long id;
+    private String email;
+    private String address;
+    private String zipcode;
+    private int totalPrice;
+    private List<OrderItemIntegrationDto> orderItems;
+
+    public OrderIntegrationDto(Order order) {
+        this.id = order.getId();
+        this.email = order.getEmail();
+        this.address = order.getAddress();
+        this.zipcode = order.getZipcode();
+        this.totalPrice = order.getTotalPrice();
+        this.orderItems = order.getOrderItems().stream()
+                .map(OrderItemIntegrationDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/shop/coffee/order/dto/OrderIntegrationViewDto.java
+++ b/src/main/java/com/shop/coffee/order/dto/OrderIntegrationViewDto.java
@@ -1,16 +1,15 @@
 package com.shop.coffee.order.dto;
 
-import com.shop.coffee.order.entity.Order;
 import lombok.Getter;
 
 @Getter
 public class OrderIntegrationViewDto {
 
     private final String viewName;
-    private final Order oldOrder;
-    private final Order newOrder;
+    private final OrderIntegrationDto oldOrder;
+    private final OrderIntegrationDto newOrder;
 
-    public OrderIntegrationViewDto(String viewName, Order oldOrder, Order newOrder) {
+    public OrderIntegrationViewDto(String viewName, OrderIntegrationDto oldOrder, OrderIntegrationDto newOrder) {
         this.viewName = viewName;
         this.oldOrder = oldOrder;
         this.newOrder = newOrder;

--- a/src/main/java/com/shop/coffee/order/dto/OrderPaymentRequestDto.java
+++ b/src/main/java/com/shop/coffee/order/dto/OrderPaymentRequestDto.java
@@ -1,8 +1,7 @@
 package com.shop.coffee.order.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.shop.coffee.order.entity.Order;
-import com.shop.coffee.orderitem.entity.OrderItem;
+import com.shop.coffee.item.dto.ItemToOrderItemDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
@@ -15,15 +14,15 @@ public class OrderPaymentRequestDto {
     private final String email;
     private final String address;
     private final String zipCode;
-    private final List<OrderItem> orderItems;
+    private final List<ItemToOrderItemDto> items;
 
     public OrderPaymentRequestDto(    @JsonProperty("email") @NotBlank String email,
                                       @JsonProperty("address") @NotBlank String address,
                                       @JsonProperty("zipCode") @NotBlank String zipCode,
-                                      @JsonProperty("orderItems") @NotEmpty List<OrderItem> orderItems) {
+                                      @JsonProperty("items") @NotEmpty List<ItemToOrderItemDto> items) {
         this.email = email;
         this.address = address;
         this.zipCode = zipCode;
-        this.orderItems = orderItems;
+        this.items = items;
     }
 }

--- a/src/main/java/com/shop/coffee/order/entity/Order.java
+++ b/src/main/java/com/shop/coffee/order/entity/Order.java
@@ -55,4 +55,9 @@ public class Order extends BaseEntity {
         this.orderStatus = orderStatus;
     }
 
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);
+        orderItem.setOrder(this); // 연관관계 설정
+    }
+
 }

--- a/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
+++ b/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
@@ -2,6 +2,8 @@ package com.shop.coffee.order.repository;
 import com.shop.coffee.order.OrderStatus;
 import com.shop.coffee.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +25,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findAllByOrderByCreatedAtDesc();
     Optional<Order> findByEmailAndOrderStatus(String email, OrderStatus orderStatus);
     Optional<Order> findByEmailAndOrderStatusAndAddressAndZipcode(String email, OrderStatus orderStatus, String address, String zipCode);
-
     Optional<Order> findByEmailAndModifiedAt(String email, LocalDateTime modifiedAt);
+    Optional<Object> findByEmail(String email);
+    @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderItems WHERE o.id = :id")
+    Optional<Order> findByIdOrderWithItems(@Param("id") Long orderId);
 }

--- a/src/main/java/com/shop/coffee/orderitem/dto/OrderItemIntegrationDto.java
+++ b/src/main/java/com/shop/coffee/orderitem/dto/OrderItemIntegrationDto.java
@@ -1,0 +1,23 @@
+package com.shop.coffee.orderitem.dto;
+
+import com.shop.coffee.item.dto.ItemIntegrationDto;
+import com.shop.coffee.orderitem.entity.OrderItem;
+import lombok.Getter;
+
+@Getter
+public class OrderItemIntegrationDto {
+
+    private Long id;
+    private ItemIntegrationDto item;
+    private int price;
+    private int quantity;
+    private String imagePath;
+
+    public OrderItemIntegrationDto(OrderItem orderItem) {
+        this.id = orderItem.getId();
+        this.item = new ItemIntegrationDto(orderItem.getItem());
+        this.price = orderItem.getPrice();
+        this.quantity = orderItem.getQuantity();
+        this.imagePath = orderItem.getImagePath();
+    }
+}

--- a/src/main/java/com/shop/coffee/orderitem/entity/OrderItem.java
+++ b/src/main/java/com/shop/coffee/orderitem/entity/OrderItem.java
@@ -17,6 +17,7 @@ public class OrderItem extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
+    @Setter
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/shop/coffee/orderitem/repository/OrderItemRepository.java
+++ b/src/main/java/com/shop/coffee/orderitem/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.shop.coffee.orderitem.repository;
+
+import com.shop.coffee.orderitem.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
+++ b/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
@@ -1,0 +1,40 @@
+package com.shop.coffee.orderitem.service;
+
+import com.shop.coffee.item.dto.ItemToOrderItemDto;
+import com.shop.coffee.item.entity.Item;
+import com.shop.coffee.item.repository.ItemRepository;
+import com.shop.coffee.order.entity.Order;
+import com.shop.coffee.orderitem.entity.OrderItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.shop.coffee.global.exception.ErrorCode.NOSINGLEITEM;
+
+@Service
+@RequiredArgsConstructor
+public class OrderItemService {
+
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public List<OrderItem> createListItem(Order newOrder, List<ItemToOrderItemDto> items) {
+
+        for(ItemToOrderItemDto item: items) {
+            Item entityItem = itemRepository.findById(item.getId())
+                    .orElseThrow(() -> new RuntimeException(NOSINGLEITEM.getMessage()));
+
+            newOrder.addOrderItem(new OrderItem(newOrder, entityItem, item.getPrice(), item.getQuantity(), item.getImagePath()));
+        }
+        newOrder.setTotalPrice(calculateTotalPrice(newOrder.getOrderItems()));
+        return newOrder.getOrderItems();
+    }
+
+    private int calculateTotalPrice(List<OrderItem> orderItems) {
+        return orderItems.stream()
+                .mapToInt(item -> item.getPrice() * item.getQuantity())
+                .sum();
+    }
+}

--- a/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
+++ b/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.shop.coffee.global.exception.ErrorCode.NO_SINGLE_ITEM;
+import static com.shop.coffee.global.exception.ErrorCode.ITEM_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class OrderItemService {
 
         for(ItemToOrderItemDto item: items) {
             Item entityItem = itemRepository.findById(item.getId())
-                    .orElseThrow(() -> new EntityNotFoundException(NO_SINGLE_ITEM.getMessage()));
+                    .orElseThrow(() -> new EntityNotFoundException(ITEM_NOT_FOUND.getMessage()));
 
             newOrder.addOrderItem(new OrderItem(newOrder, entityItem, item.getPrice(), item.getQuantity(), item.getImagePath()));
         }

--- a/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
+++ b/src/main/java/com/shop/coffee/orderitem/service/OrderItemService.java
@@ -5,13 +5,14 @@ import com.shop.coffee.item.entity.Item;
 import com.shop.coffee.item.repository.ItemRepository;
 import com.shop.coffee.order.entity.Order;
 import com.shop.coffee.orderitem.entity.OrderItem;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.shop.coffee.global.exception.ErrorCode.NOSINGLEITEM;
+import static com.shop.coffee.global.exception.ErrorCode.NO_SINGLE_ITEM;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class OrderItemService {
 
         for(ItemToOrderItemDto item: items) {
             Item entityItem = itemRepository.findById(item.getId())
-                    .orElseThrow(() -> new RuntimeException(NOSINGLEITEM.getMessage()));
+                    .orElseThrow(() -> new EntityNotFoundException(NO_SINGLE_ITEM.getMessage()));
 
             newOrder.addOrderItem(new OrderItem(newOrder, entityItem, item.getPrice(), item.getQuantity(), item.getImagePath()));
         }


### PR DESCRIPTION
### 💻 작업 내용
주문 통합 데이터 dto를 전송하도록 변경하였습니다.
결제시 불러오는 주문 내용을 OrderItem -> Item으로 변경하여 결제 로직을 수정하였습니다.

<br>

### ✅ 체크 리스트
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 풀 리퀘스트 제목에 커밋 메시지 컨벤션을 적용했습니다.

<br>

### ⚠️ 주의 사항
<!-- 주의해야 할 점, 참고해야 할 점이 있다면 설명해주세요. -->
메인 페이지에서 결재 요청 json시, orderItems -> items를 사용해야 됩니다.
ApiV1OrderControllerTest5의 createOrderJson을 확인해주세요

### 🗨️ 리뷰 요구 사항
dto가 변경되었는데, oldOrder, newOrder의 model 속성명은 동일합니다. 필요시 model 속성 명도 변경하겠습니다.
OrderIntegrationDto를 전송하는것은 동일합니다.