### PR TITLE
perf: 스케줄링 성능 최적화

### DIFF
--- a/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
+++ b/src/main/java/com/shop/coffee/order/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.shop.coffee.order.repository;
 
 import com.shop.coffee.order.OrderStatus;
 import com.shop.coffee.order.entity.Order;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -36,4 +37,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByEmail(String email);
     @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderItems oi JOIN FETCH oi.item WHERE o.id = :id")
     Optional<Order> findByIdFetchOrderItemsAndItems(@Param("id") Long orderId);
+
+    // createdAt이 start와 end 사이에 포함되고, OrderStatus가 RECEIVED인 Order 조회
+    List<Order> findByCreatedAtBetweenAndOrderStatus(LocalDateTime start, LocalDateTime end, OrderStatus orderStatus);
 }

--- a/src/main/java/com/shop/coffee/order/service/scheduler/OrderStatusUpdateScheduler.java
+++ b/src/main/java/com/shop/coffee/order/service/scheduler/OrderStatusUpdateScheduler.java
@@ -3,6 +3,7 @@ package com.shop.coffee.order.service.scheduler;
 import com.shop.coffee.order.OrderStatus;
 import com.shop.coffee.order.entity.Order;
 import com.shop.coffee.order.repository.OrderRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,10 @@ public class OrderStatusUpdateScheduler {
     public void updateOrderStatus() {
         log.info("=== 배송 일괄 처리 시작 ===");
 
-        List<Order> receivedOrders = orderRepository.findByOrderStatus(OrderStatus.RECEIVED);
+        LocalDateTime start = LocalDateTime.now().minusDays(1).withHour(14).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime end = LocalDateTime.now();
+
+        List<Order> receivedOrders = orderRepository.findByCreatedAtBetweenAndOrderStatus(start, end, OrderStatus.RECEIVED);
 
         receivedOrders.forEach(
                 order -> {


### PR DESCRIPTION
### 💻 작업 내용
<!-- 해당 PR에서 작업한 내용, 변경 사항 등을 설명해주세요. -->
- 기존의 스케줄러는 `OrderStatus`만을 이용해 주문 내역을 조회했습니다.
- 그러나 오늘을 기준으로 어제 오후 2시 전의 주문 내역은 조회할 필요가 없습니다.
- 따라서 주문 생성 시간인 `createdAt`과 `OrderStatus`를 함께 사용해 탐색 범위를 좁혔습니다.
- 별도의 테스트 코드 작성 없이, h2 DB로 상태 변경을 확인했습니다.

<br>

### ✅ 체크 리스트
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 풀 리퀘스트 제목에 커밋 메시지 컨벤션을 적용했습니다.

<br>

### ⚠️ 주의 사항
<!-- 주의해야 할 점, 참고해야 할 점이 있다면 설명해주세요. -->
<!-- 내용이 없다면 X를 입력하세요. -->
X

<br>

### 🗨️ 리뷰 요구 사항
<!-- 리뷰어가 중점적으로 확인해주길 바라는 부분을 작성하고, 리뷰어를 할당해주세요. -->
<!-- 리뷰가 필요하지 않다면 X를 입력하세요. -->
X