### PR TITLE
style: 상이 배송지 주문 통합 뷰 스타일 수정

### DIFF
--- a/src/main/resources/templates/different_location_order_integration.html
+++ b/src/main/resources/templates/different_location_order_integration.html
@@ -45,11 +45,13 @@
                     </div>
                     <!-- 기존 주문 상품 출력 끝 -->
 
-                    <div class="text-xl">
+                    <div class="text-lg mt-auto border-t border-t-customBlack p-2">
+                        <span th:text="'배송지'"></span>
+                        <br>
                         <label>
-                            <input type="radio" name="location" value="oldOrderLocation" class="radio radio-lg" />
+                            <input type="radio" name="location" value="oldOrderLocation" class="radio radio-xs bg-white border-white checked:bg-white" />
                         </label>
-                        <span th:text="|${oldOrder.address} ${oldOrder.zipcode}|"></span>
+                        <span th:text="|${oldOrder.address} (${oldOrder.zipcode})|"></span>
                     </div>
 
                 </div>
@@ -80,11 +82,13 @@
                     </div>
                     <!-- 신규 주문 상품 출력 끝 -->
 
-                    <div class="text-xl">
+                    <div class="text-lg mt-auto border-t border-t-customBlack p-2">
+                        <span th:text="'배송지'"></span>
+                        <br>
                         <label>
-                            <input type="radio" name="location" value="newOrderLocation" class="radio radio-lg" checked="checked" />
+                            <input type="radio" name="location" value="newOrderLocation" class="radio radio-xs bg-white border-white checked:bg-white" checked="checked" />
                         </label>
-                        <span th:text="|${newOrder.address} ${newOrder.zipcode}|"></span>
+                        <span th:text="|${newOrder.address} (${newOrder.zipcode})|"></span>
                     </div>
 
                 </div>


### PR DESCRIPTION
### 💻 작업 내용
<!-- 해당 PR에서 작업한 내용, 변경 사항 등을 설명해주세요. -->
- 상이 배송지 주문 통합 뷰에서 배송지 컴포넌트의 스타일을 수정했습니다.
    - 라디오 버튼의 크기와 색상을 변경했습니다.
    - 배송지 나열 방식을 변경했습니다.
        - 이전: 주소 우편번호
        - 현재: 주소 (우편번호)  
    - 주문 상품 내역과 배송지를 구분하기 위한 구분선을 추가했습니다.

<br>

### ✅ 체크 리스트
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 풀 리퀘스트 제목에 커밋 메시지 컨벤션을 적용했습니다.

<br>

### ⚠️ 주의 사항
<!-- 주의해야 할 점, 참고해야 할 점이 있다면 설명해주세요. -->
<!-- 내용이 없다면 X를 입력하세요. -->
X

<br>

### 🗨️ 리뷰 요구 사항
<!-- 리뷰어가 중점적으로 확인해주길 바라는 부분을 작성하고, 리뷰어를 할당해주세요. -->
<!-- 리뷰가 필요하지 않다면 X를 입력하세요. -->
X