### PR TITLE
fix: 상품 요약 갯수 정상적으로 계산

### DIFF
--- a/src/main/java/com/shop/coffee/order/dto/OrderSummaryDto.java
+++ b/src/main/java/com/shop/coffee/order/dto/OrderSummaryDto.java
@@ -2,6 +2,7 @@ package com.shop.coffee.order.dto;
 
 import com.shop.coffee.order.OrderStatus;
 import com.shop.coffee.order.entity.Order;
+import com.shop.coffee.orderitem.entity.OrderItem;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -28,10 +29,14 @@ public class OrderSummaryDto {
     }
 
     private String getSummaryItemName(Order order) {
-        if (order.getOrderItems().size() == 1) {
+        int totalItemCount = order.getOrderItems().stream()
+                .mapToInt(OrderItem::getQuantity)
+                .sum();
+
+        if (totalItemCount == 1) {
             return order.getOrderItems().getFirst().getItem().getName();
         } else {
-            return order.getOrderItems().getFirst().getItem().getName() + " 외 " + (order.getOrderItems().size() - 1) + "건";
+            return order.getOrderItems().getFirst().getItem().getName() + " 외 " + (totalItemCount - 1) + "건";
         }
     }
 


### PR DESCRIPTION
### 💻 작업 내용
<!-- 해당 PR에서 작업한 내용, 변경 사항 등을 설명해주세요. -->
1. 하나의 주문에 A커피가 2개, B커피가 3개가 포함되어 있다면, " A커피 외 1개" 가 아닌 "A커피 외 4개" 로 변경, 즉 상품의 총 갯수에 따라 결정

<br>

### ✅ 체크 리스트
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 테스트 코드를 작성했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 풀 리퀘스트 제목에 커밋 메시지 컨벤션을 적용했습니다.

<br>

### ⚠️ 주의 사항
<!-- 주의해야 할 점, 참고해야 할 점이 있다면 설명해주세요. -->
<!-- 내용이 없다면 X를 입력하세요. -->
X

<br>

### 🗨️ 리뷰 요구 사항
<!-- 리뷰어가 중점적으로 확인해주길 바라는 부분을 작성하고, 리뷰어를 할당해주세요. -->
<!-- 리뷰가 필요하지 않다면 X를 입력하세요. -->
X